### PR TITLE
Update Oxford Dataset version

### DIFF
--- a/src/unet/datasets/oxford_iiit_pet.py
+++ b/src/unet/datasets/oxford_iiit_pet.py
@@ -48,7 +48,7 @@ def load_data(buffer_size=1000, **kwargs) -> Tuple[tf.data.Dataset, tf.data.Data
 
 
 def _load_without_checksum_verification(**kwargs) -> Tuple[Dict, DatasetInfo]:
-    builder = tfds.builder('oxford_iiit_pet:3.1.0')
+    builder = tfds.builder('oxford_iiit_pet:3.2.0')
     # by setting register_checksums as True to pass the check
     config = tfds.download.DownloadConfig(register_checksums=True)
     builder.download_and_prepare(download_config=config)


### PR DESCRIPTION
As the Oxford Dataset version is updated to 3.2.0, the existing code with version 3.1.0 fails with the following error when I have tried on the Google Colab file given in the repository.


AssertionError: Failed to construct dataset oxford_iiit_pet:3.1.0: Dataset oxford_iiit_pet cannot be loaded at version 3.1.0, only: 3.2.0.